### PR TITLE
fix metrics

### DIFF
--- a/src/metrics/impl/session_impl.cpp
+++ b/src/metrics/impl/session_impl.cpp
@@ -69,6 +69,7 @@ namespace lean::metrics {
       }
 
       stop();
+      return;
     }
 
     handleRequest(parser_->release());

--- a/src/metrics/session.hpp
+++ b/src/metrics/session.hpp
@@ -37,6 +37,9 @@ namespace lean::metrics {
       static constexpr size_t kDefaultRequestSize = 10000u;
       static constexpr Duration kDefaultTimeout = std::chrono::seconds(30);
 
+      // Fixes default field values with boost::di.
+      Configuration() = default;
+
       size_t max_request_size{kDefaultRequestSize};
       Duration operation_timeout{kDefaultTimeout};
     };


### PR DESCRIPTION
- closes #16
- boost di zero initialized fields
- missing return on read error