### PR TITLE
add Docker support with multi-stage build

### DIFF
--- a/.ci/.env
+++ b/.ci/.env
@@ -1,9 +1,9 @@
 GCC_VERSION=14
+RUST_VERSION=stable
 LINUX_PACKAGES="make \
   autoconf \
   automake \
   build-essential \
-  cargo \
   curl \
   gcc-$GCC_VERSION \
   g++-$GCC_VERSION \

--- a/.ci/scripts/init.sh
+++ b/.ci/scripts/init.sh
@@ -15,6 +15,11 @@ main() {
       apt update && apt install -y  $LINUX_PACKAGES
       update-alternatives --install /usr/bin/gcc          gcc          /usr/bin/gcc-$GCC_VERSION 90
       update-alternatives --install /usr/bin/g++          g++          /usr/bin/g++-$GCC_VERSION 90
+      # Install Rust via rustup
+      if ! command -v rustup >/dev/null 2>&1; then
+        echo "=== Installing Rust ${RUST_VERSION} via rustup..."
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal
+      fi
       if [ -f "$HOME/.cargo/env" ]; then
         source "$HOME/.cargo/env"
       fi

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -23,6 +23,7 @@ env:
   RUSTUP_HOME: ~/.rustup
   CACHE_PATH: |
     ~/.cargo
+    ~/.rustup
     ~/.hunter
     ~/.cache/pip
     ~/.cache/vcpkg
@@ -44,12 +45,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
-      - name: "Set up Rust"
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
 
       - name: "Restore cache dependencies"
         id: cache-restore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# ==================== Stage 1: Builder (init + configure + build) ====================
+FROM ubuntu:24.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CMAKE_VERSION=3.31.1
+ARG GCC_VERSION=14
+ARG RUST_VERSION=stable
+
+ENV DEBIAN_FRONTEND=${DEBIAN_FRONTEND}
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+ENV GCC_VERSION=${GCC_VERSION}
+ENV RUST_VERSION=${RUST_VERSION}
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+
+ENV PROJECT=/qlean-mini
+ENV VENV=${PROJECT}/.venv
+ENV BUILD=${PROJECT}/.build
+ENV PATH=${VENV}/bin:/root/.cargo/bin:${PATH}
+ENV CARGO_HOME=/root/.cargo
+ENV RUSTUP_HOME=/root/.rustup
+
+WORKDIR ${PROJECT}
+
+# Copy project files
+COPY . ${PROJECT}
+
+# Run all inits and build with vcpkg cache
+RUN set -eux; \
+    chmod +x .ci/scripts/*.sh; \
+    # System dependencies and Rust via init.sh
+    ./.ci/scripts/init.sh; \
+    # Python venv and cmake via init_py
+    make init_py
+
+# Configure and build with full vcpkg cache
+RUN --mount=type=cache,target=/qlean-mini/.vcpkg,id=vcpkg-full \
+    set -eux; \
+    export PATH="${HOME}/.cargo/bin:${PATH}"; \
+    source ${HOME}/.cargo/env 2>/dev/null || true; \
+    # Init vcpkg inside cache mount if needed
+    if [ ! -f "/qlean-mini/.vcpkg/vcpkg" ]; then \
+      make init_vcpkg; \
+    fi; \
+    make configure; \
+    make build; \
+    # Collect artifacts
+    mkdir -p /opt/artifacts/bin /opt/artifacts/modules /opt/artifacts/lib /opt/artifacts/vcpkg; \
+    # Copy executable
+    cp -v ${BUILD}/src/executable/qlean /opt/artifacts/bin/; \
+    # Copy all module .so files
+    find ${BUILD}/src/modules -type f -name "*_module.so" -exec cp -v {} /opt/artifacts/modules/ \; || true; \
+    # Copy all other project .so libraries (app, utils, etc)
+    find ${BUILD}/src -type f -name "*.so" ! -name "*_module.so" -exec cp -v {} /opt/artifacts/lib/ \; || true; \
+    # Copy vcpkg installed libraries
+    if [ -d "${BUILD}/vcpkg_installed" ]; then \
+      cp -R ${BUILD}/vcpkg_installed /opt/artifacts/vcpkg/installed; \
+    fi; \
+    # List collected artifacts
+    echo "=== Collected artifacts ==="; \
+    ls -lh /opt/artifacts/bin/; \
+    ls -lh /opt/artifacts/modules/ || true; \
+    ls -lh /opt/artifacts/lib/ || true
+
+# ==================== Stage 2: Runtime ====================
+FROM ubuntu:24.04 AS runtime
+
+# Install minimal runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libstdc++6 \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Environment variables for runtime
+ENV LD_LIBRARY_PATH=/opt/qlean/lib:/opt/qlean/vcpkg/installed/x64-linux/lib:/opt/qlean/vcpkg/installed/x64-linux-dynamic/lib:/opt/qlean/vcpkg/installed/lib:/usr/local/lib
+ENV QLEAN_MODULES_DIR=/opt/qlean/modules
+
+WORKDIR /work
+
+# Copy artifacts from builder
+COPY --from=builder /opt/artifacts/bin/qlean /usr/local/bin/qlean
+COPY --from=builder /opt/artifacts/lib/ /opt/qlean/lib/
+COPY --from=builder /opt/artifacts/modules/ /opt/qlean/modules/
+COPY --from=builder /opt/artifacts/vcpkg/installed/ /opt/qlean/vcpkg/installed/
+
+# Verify artifacts
+RUN echo "=== Runtime image contents ===" && \
+    ls -lh /usr/local/bin/qlean && \
+    echo "=== Project libraries ===" && \
+    ls -lh /opt/qlean/lib/ || true && \
+    echo "=== Modules ===" && \
+    ls -lh /opt/qlean/modules/ || true
+
+ENTRYPOINT ["qlean", "--modules-dir", "/opt/qlean/modules"]
+CMD ["--help"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,43 @@
+# Use existing builder image
+FROM qlean-mini:latest-builder AS builder
+
+# ==================== Stage 2: Runtime ====================
+FROM ubuntu:24.04 AS runtime
+
+# Install minimal runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libstdc++6 \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Environment variables for runtime
+ENV LD_LIBRARY_PATH=/opt/qlean/lib:/opt/qlean/vcpkg/installed/x64-linux/lib:/opt/qlean/vcpkg/installed/x64-linux-dynamic/lib:/opt/qlean/vcpkg/installed/lib:/usr/local/lib
+ENV QLEAN_MODULES_DIR=/opt/qlean/modules
+
+WORKDIR /work
+
+# Copy binary
+COPY --from=builder /qlean-mini/.build/src/executable/qlean /usr/local/bin/qlean
+# Copy all project .so libraries
+COPY --from=builder /qlean-mini/.build/src/app/*.so /opt/qlean/lib/
+COPY --from=builder /qlean-mini/.build/src/utils/*.so /opt/qlean/lib/
+# Copy modules
+COPY --from=builder /qlean-mini/.build/src/modules/example/libexample_module.so /opt/qlean/modules/
+COPY --from=builder /qlean-mini/.build/src/modules/networking/libnetworking_module.so /opt/qlean/modules/
+COPY --from=builder /qlean-mini/.build/src/modules/production/libproduction_module.so /opt/qlean/modules/
+COPY --from=builder /qlean-mini/.build/src/modules/synchronizer/libsynchronizer_module.so /opt/qlean/modules/
+# Copy vcpkg libraries
+COPY --from=builder /qlean-mini/.build/vcpkg_installed/ /opt/qlean/vcpkg/installed/
+
+# Verify artifacts
+RUN echo "=== Runtime image contents ===" && \
+    ls -lh /usr/local/bin/qlean && \
+    echo "=== Project libraries ===" && \
+    ls -lh /opt/qlean/lib/ || true && \
+    echo "=== Modules ===" && \
+    ls -lh /opt/qlean/modules/ || true
+
+ENTRYPOINT ["qlean", "--modules-dir", "/opt/qlean/modules"]
+CMD ["--help"]
+


### PR DESCRIPTION
- Add Dockerfile with 2-stage build (builder and runtime)
- Add Dockerfile.runtime for fast runtime-only rebuilds
- Update Makefile with Docker build targets (docker_build_builder, docker_build_runtime, docker_build_all)
- Install Rust via rustup in init.sh script instead of apt
- Add RUST_VERSION to .env configuration
- Update CI workflow to cache Rust via rustup
- Configure vcpkg caching with BuildKit mount
- Fix library and module paths in runtime stage
- Set --modules-dir in ENTRYPOINT for convenience